### PR TITLE
Added WD device type sensors.

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -58,7 +58,44 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
             device_class=BinarySensorDeviceClass.DOOR,
             on_value="1",
         ),
-    )
+    ),
+    "WD": (
+        HonBinarySensorEntityDescription(
+            key="attributes.lastConnEvent.category",
+            name="Remote Control",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            on_value="CONNECTED",
+            icon="mdi:remote"
+        ),
+        HonBinarySensorEntityDescription(
+            key="startProgram.prewash",
+            name="Pre Wash",
+        ),
+        HonBinarySensorEntityDescription(
+            key="extraRinse1",
+            name="Extra Rinse 1",
+        ),
+        HonBinarySensorEntityDescription(
+            key="extraRinse2",
+            name="Extra Rinse 2",
+        ),
+        HonBinarySensorEntityDescription(
+            key="extraRinse3",
+            name="Extra Rinse 3",
+        ),
+        HonBinarySensorEntityDescription(
+            key="goodNight",
+            name="Good Night Mode",
+        ),
+        HonBinarySensorEntityDescription(
+            key="acquaplus",
+            name="Acqua Plus",
+        ),
+        HonBinarySensorEntityDescription(
+            key="anticrease",
+            name="Anti-Crease",
+        ),
+    ),
 }
 
 
@@ -77,7 +114,7 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if descriptions := BINARY_SENSORS.get(device.appliance_type):
             for description in descriptions:
                 if not device.get(description.key):
-                    _LOGGER.info("Can't setup %s", description.key)
+                    _LOGGER.warning("[%s] Can't setup %s", device.appliance_type, description.key)
                     continue
                 appliances.extend([
                     HonBinarySensorEntity(hass, coordinator, entry, device, description)]

--- a/custom_components/hon/number.py
+++ b/custom_components/hon/number.py
@@ -74,6 +74,15 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG
         ),
     ),
+    "WD": (
+        NumberEntityDescription(
+            key="startProgram.delayTime",
+            name="Delay Time",
+            icon="mdi:timer-plus",
+            entity_category=EntityCategory.CONFIG,
+            native_unit_of_measurement=UnitOfTime.MINUTES
+        ),
+    ),
 }
 
 

--- a/custom_components/hon/select.py
+++ b/custom_components/hon/select.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+
 from pyhon import HonConnection
 from pyhon.device import HonDevice
 from pyhon.parameter import HonParameterFixed
@@ -12,6 +14,8 @@ from homeassistant.helpers.entity import EntityCategory
 
 from .const import DOMAIN
 from .hon import HonEntity, HonCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 SELECTS = {
     "WM": (
@@ -50,7 +54,15 @@ SELECTS = {
             icon="mdi:timer",
             unit_of_measurement=UnitOfTime.MINUTES
         ),
-    )
+    ),
+    "WD": (
+        SelectEntityDescription(
+            key="startProgram.program",
+            name="Program",
+            entity_category=EntityCategory.CONFIG,
+            translation_key="programs"
+        ),
+    ),
 }
 
 
@@ -69,6 +81,7 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if descriptions := SELECTS.get(device.appliance_type):
             for description in descriptions:
                 if not device.get(description.key):
+                    _LOGGER.warning("[%s] Can't setup %s", device.appliance_type, description.key)
                     continue
                 appliances.extend([
                     HonSelectEntity(hass, coordinator, entry, device, description)]

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -9,7 +9,15 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfEnergy, UnitOfVolume, UnitOfMass, UnitOfPower, UnitOfTime
+from homeassistant.const import (
+    REVOLUTIONS_PER_MINUTE,
+    UnitOfEnergy,
+    UnitOfVolume,
+    UnitOfMass,
+    UnitOfPower,
+    UnitOfTime,
+    UnitOfTemperature
+)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.typing import StateType
@@ -141,7 +149,68 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
             icon="mdi:thermometer",
             translation_key="tumbledryertemplevel"
         ),
-    )
+    ),
+    "WD": (
+        SensorEntityDescription(
+            key="machMode",
+            name="Machine Status",
+            icon="mdi:information",
+            translation_key="mode"
+        ),
+        SensorEntityDescription(
+            key="spinSpeed",
+            name="Spin Speed",
+            icon="mdi:fast-forward-outline",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
+        ),
+        SensorEntityDescription(
+            key="remainingTimeMM",
+            name="Remaining Time",
+            icon="mdi:timer",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTime.MINUTES,
+        ),
+        SensorEntityDescription(
+            key="delayTime",
+            name="Start Time",
+            icon="mdi:clock-start",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTime.MINUTES,
+        ),
+        SensorEntityDescription(
+            key="prCode",
+            name="Current Program",
+            icon="mdi:tumble-dryer",
+        ),
+        SensorEntityDescription(
+            key="prPhase",
+            name="Program Phase",
+            icon="mdi:tumble-dryer",
+        ),
+        SensorEntityDescription(
+            key="dryLevel",
+            name="Dry level",
+            icon="mdi:hair-dryer",
+        ),
+        SensorEntityDescription(
+            key="dirtyLevel",
+            name="Dirt level",
+            icon="mdi:liquid-spot",
+        ),
+        SensorEntityDescription(
+            key="steamLevel",
+            name="Steam level",
+            icon="mdi:smoke",
+        ),
+        SensorEntityDescription(
+            key="temp",
+            name="Current Temperature",
+            icon="mdi:thermometer",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        ),
+    ),
 }
 
 
@@ -160,6 +229,7 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
         if descriptions := SENSORS.get(device.appliance_type):
             for description in descriptions:
                 if not device.get(description.key):
+                    _LOGGER.warning("[%s] Can't setup %s", device.appliance_type, description.key)
                     continue
                 appliances.extend([
                     HonSensorEntity(hass, coordinator, entry, device, description)]

--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -1,3 +1,5 @@
+import logging
+
 from dataclasses import dataclass
 from typing import Any
 
@@ -10,6 +12,7 @@ from pyhon.device import HonDevice
 from .const import DOMAIN
 from .hon import HonCoordinator, HonEntity
 
+_LOGGER = logging.getLogger(__name__)
 
 @dataclass
 class HonSwitchEntityDescriptionMixin:
@@ -69,6 +72,22 @@ SWITCHES: dict[str, tuple[HonSwitchEntityDescription, ...]] = {
             turn_off_key="resumeProgram",
         ),
     ),
+    "WD": (
+        HonSwitchEntityDescription(
+            key="active",
+            name="Washing Machine",
+            icon="mdi:washing-machine",
+            turn_on_key="startProgram",
+            turn_off_key="stopProgram",
+        ),
+        HonSwitchEntityDescription(
+            key="pause",
+            name="Pause Washing Machine",
+            icon="mdi:pause",
+            turn_on_key="pauseProgram",
+            turn_off_key="resumeProgram",
+        ),
+    ),
 }
 
 
@@ -90,6 +109,8 @@ async def async_setup_entry(hass, entry: ConfigEntry, async_add_entities) -> Non
                     appliances.extend([
                         HonSwitchEntity(hass, coordinator, entry, device, description)]
                     )
+                else:
+                    _LOGGER.warning("[%s] Can't setup %s", device.appliance_type, description.key)
 
     async_add_entities(appliances)
 

--- a/custom_components/hon/translations/bg.json
+++ b/custom_components/hon/translations/bg.json
@@ -377,6 +377,7 @@
           "single_item_steam": "Single Item + Steam",
           "smart_wash": "Smart Wash",
           "soft_care": "Soft Care",
+          "soft_care_steam": "Soft Care + Steam",
           "soft_care_steam_title": "Soft Care + Steam",
           "special_39": "Special 39'",
           "special_39_full_load": "Special 39'",

--- a/custom_components/hon/translations/en.json
+++ b/custom_components/hon/translations/en.json
@@ -377,6 +377,7 @@
           "single_item_steam": "Single Item + Steam",
           "smart_wash": "Smart Wash",
           "soft_care": "Soft Care",
+          "soft_care_steam": "Soft Care + Steam",
           "soft_care_steam_title": "Soft Care + Steam",
           "special_39": "Special 39'",
           "special_39_full_load": "Special 39'",


### PR DESCRIPTION
Hey,

After some testing I finished with the following useful sensors for my device type. In the beginning I was just copying the WM interface but there is notable difference, therefore I did not just do a copy of the dictionary.

In the future we may need to implement a "base" device and inherit from it, but I think we should way for more device contributions to know which sensors and switches are really global.

Let me know if you still think we need more changes.