### PR TITLE
Adding HO integration

### DIFF
--- a/custom_components/hon/button.py
+++ b/custom_components/hon/button.py
@@ -35,6 +35,20 @@ BUTTONS: dict[str, tuple[ButtonEntityDescription, ...]] = {
             translation_key="stop_program",
         ),
     ),
+    "HO": (
+        ButtonEntityDescription(
+            key="startProgram",
+            name="Start Program",
+            icon="mdi:hvac",
+            translation_key="start_program",
+        ),
+        ButtonEntityDescription(
+            key="stopProgram",
+            name="Stop Program",
+            icon="mdi:hvac-off",
+            translation_key="stop_program",
+        ),
+    ),
 }
 
 

--- a/custom_components/hon/number.py
+++ b/custom_components/hon/number.py
@@ -162,6 +162,20 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
             translation_key="freezer_temp_sel",
         ),
     ),
+    "HO": (
+        HonNumberEntityDescription(
+            key="startProgram.windSpeed",
+            name="Wind speed",
+            icon="mdi:fan",
+            entity_category=EntityCategory.CONFIG,
+        ),
+        HonNumberEntityDescription(
+            key="startProgram.lightStatus",
+            name="Light status",
+            icon="mdi:lightbulb",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
 }
 
 NUMBERS["WD"] = unique_entities(NUMBERS["WM"], NUMBERS["TD"])

--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -535,6 +535,71 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
             key="errors", name="Error", icon="mdi:math-log", translation_key="errors"
         ),
     ),
+    "HO": (
+        HonSensorEntityDescription(
+            key="delayTime",
+            name="Delay time",
+            icon="mdi:clock-start",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit_of_measurement=UnitOfTime.MINUTES,
+        ),
+        HonSensorEntityDescription(
+            key="delayTimeStatus",
+            name="Delay time status",
+            icon="mdi:clock-start",
+        ),
+        HonSensorEntityDescription(
+            key="errors",
+            name="Errors",
+            icon="mdi:alert-circle",
+        ),
+        HonSensorEntityDescription(
+            key="filterCleaningAlarmStatus",
+            name="Filter Cleaning Alarm Status",
+        ),
+        HonSensorEntityDescription(
+            key="filterCleaningStatus",
+            name="Filter Cleaning Status",
+        ),
+        HonSensorEntityDescription(
+            key="lastWorkTime",
+            name="Last Work Time",
+            icon="mdi:clock-start",
+        ),
+        HonSensorEntityDescription(
+            key="lightStatus",
+            name="Light Status",
+            icon="mdi:lightbulb",
+        ),
+        HonSensorEntityDescription(
+            key="machMode",
+            name="Mach Mode",
+        ),
+        HonSensorEntityDescription(
+            key="onOffStatus",
+            name="On / Off Status",
+            icon="mdi:lightbulb",
+        ),
+        HonSensorEntityDescription(
+            key="quickDelayTimeStatus",
+            name="Quick Delay Time Status",
+        ),
+        HonSensorEntityDescription(
+            key="rgbLightColors",
+            name="RGB Light Color",
+            icon="mdi:lightbulb",
+        ),
+        HonSensorEntityDescription(
+            key="rgbLightStatus",
+            name="RGB Light Status",
+            icon="mdi:lightbulb",
+        ),
+        HonSensorEntityDescription(
+            key="windSpeed",
+            name="Wind Speed",
+            icon="mdi:fan",
+        ),
+    ),
 }
 SENSORS["WD"] = unique_entities(SENSORS["WM"], SENSORS["TD"])
 


### PR DESCRIPTION
Adding HO integration (Kitchen Hood appliance). Working good with Haier HADG6DS46BWIFI (fw 3.8.0).

What is already done and working:
- buttons to start and stop,
- number selector for "Wind Speed" and "Light On/Off",
- all sensors that were detected on HADG6DS46BWIFI unit.

What is not working:
- delays and timers that can be set from mobile app.

What need to be clean:
- all sensors need to be described properly (some purpose of them I don't understand),
- translation data for the device (didn't had time yet).