### PR TITLE
Fix deprecated import

### DIFF
--- a/custom_components/hon/button.py
+++ b/custom_components/hon/button.py
@@ -4,7 +4,7 @@ import pkg_resources
 from homeassistant.components import persistent_notification
 from homeassistant.components.button import ButtonEntityDescription, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.helpers.entity import EntityCategory
 from pyhon.appliance import HonAppliance
 
 from .const import DOMAIN

--- a/custom_components/hon/switch.py
+++ b/custom_components/hon/switch.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntityDescription, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.core import callback
 from pyhon.parameter.base import HonParameter
 from pyhon.parameter.range import HonParameterRange


### PR DESCRIPTION
The "EntityCategory" import was moved from homeassistant.const to homeassistant.helpers.entity.
Some entities were up to date, but Switch and Button weren't, so these reported some errors in HomeAssistant logs.