### PR TITLE
Added preheat binary sensor for ovens

### DIFF
--- a/custom_components/hon/binary_sensor.py
+++ b/custom_components/hon/binary_sensor.py
@@ -123,6 +123,14 @@ BINARY_SENSORS: dict[str, tuple[HonBinarySensorEntityDescription, ...]] = {
             icon="mdi:power-cycle",
             translation_key="on",
         ),
+        HonBinarySensorEntityDescription(
+            key="attributes.parameters.preheatStatus",
+            name="Preheat",
+            device_class=BinarySensorDeviceClass.RUNNING,
+            on_value=1,
+            icon="mdi:heat-wave",
+            translation_key="on",
+        ),
     ),
     "IH": (
         HonBinarySensorEntityDescription(


### PR DESCRIPTION
Preheat status for ovens.

I found it helpful for doing notifications through the speakers of my house to know when the oven has stopped preheating, as the chime of the oven is very quiet.

Is my first addition to this repo, I didn't test it as I don't know how, but I think I did it correctly.

Thank you!