### PR TITLE
Bug: Unit of measurement error

### DIFF
--- a/custom_components/hon/sensor.py
+++ b/custom_components/hon/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     UnitOfEnergy,
     UnitOfVolume,
     UnitOfMass,
+    UnitOfPower,
     UnitOfTime,
     UnitOfTemperature,
 )
@@ -83,7 +84,7 @@ SENSORS: dict[str, tuple[SensorEntityDescription, ...]] = {
             name="Current Electricity Used",
             state_class=SensorStateClass.MEASUREMENT,
             device_class=SensorDeviceClass.POWER,
-            native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+            native_unit_of_measurement=UnitOfPower.WATT,
             icon="mdi:lightning-bolt",
             translation_key="energy_current",
         ),


### PR DESCRIPTION
Home Assistant reported:

(<class 'custom_components.hon.sensor.HonSensorEntity'>) is using native unit of measurement 'kWh' which is not a valid unit for the device class ('power') it is using; expected one of ['W', 'kW', 'TW', 'GW', 'MW'];

it fixes the issue https://github.com/Andre0512/hon/issues/201