### PR TITLE
Fix compatibility with new HA versions

### DIFF
--- a/custom_components/hon/__init__.py
+++ b/custom_components/hon/__init__.py
@@ -6,7 +6,7 @@ import voluptuous as vol  # type: ignore[import-untyped]
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers import config_validation as cv, aiohttp_client
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from pyhon import Hon
 
@@ -27,7 +27,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     session = aiohttp_client.async_get_clientsession(hass)
     if (config_dir := hass.config.config_dir) is None:
         raise ValueError("Missing Config Dir")
@@ -48,19 +48,20 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     coordinator: DataUpdateCoordinator[dict[str, Any]] = DataUpdateCoordinator(
         hass, _LOGGER, name=DOMAIN
     )
-    hon.subscribe_updates(coordinator.async_set_updated_data)
+    def make_threadsafe_callback(hass, callback):
+        def wrapper(*args, **kwargs):
+            hass.loop.call_soon_threadsafe(callback, *args, **kwargs)
+        return wrapper
+    hon.subscribe_updates(make_threadsafe_callback(hass, coordinator.async_set_updated_data))
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.unique_id] = {"hon": hon, "coordinator": coordinator}
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     refresh_token = hass.data[DOMAIN][entry.unique_id]["hon"].api.auth.refresh_token
 
     hass.config_entries.async_update_entry(


### PR DESCRIPTION
This PR implements multiple fixes to ensure compatibility with the latest versions of Home Assistant:

* **Thread safety for DataUpdateCoordinator:**
  Update callbacks are now always executed on the Home Assistant event loop, preventing `RuntimeError: Detected code that calls async_write_ha_state from a thread other than the event loop`. Previously, this threading issue prevented new data from being received and entity updates from working.

* **Correct use of async\_forward\_entry\_setup:**
  Platforms are now set up using `await hass.config_entries.async_forward_entry_setup(...)` instead of launching them as background tasks, as required by recent Home Assistant core changes.

* **Remove usage of deprecated HomeAssistantType:**
  All type annotations now use `HomeAssistant` from `homeassistant.core`, in line with the latest recommendations and deprecations.

These changes address a number of breaking changes introduced in recent and upcoming Home Assistant releases, ensuring this integration continues to work reliably.

**Closes #300 (?), #302, #309, #310, partially #303, etc.**
